### PR TITLE
Change theme specification to fix RTD

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,7 @@ site_description: "A Kubernetes/OpenShift operator to manage Gluster clusters"
 repo_url: "https://github.com/gluster/anthill/"
 edit_uri: "blob/master/docs/"
 # readthedocs.org supports only readthedocs theme
-theme: "readthedocs"
+theme:
+  name: "readthedocs"
 # Broken documentation links break the build
 strict: true


### PR DESCRIPTION
**Describe what this PR does**
RTD overrides some theme settings in the `mkdocs.yml` file. Using the old method for specifying the theme (`theme: name`) leads to RTD appending a `theme_dir: ...` setting to the file. This was deprecated in mkdocs 0.17.0, and so it produces a warning. This warning breaks the build since we use `strict: true`.
RCA: https://readthedocs.org/api/v2/build/7553542.txt (search: theme_dir)

This patch moves to the new way of specifying the theme, which should cause RTD to use `custom_dir` which is the supported method.
See: https://github.com/rtfd/readthedocs.org/blob/be1912e4ea0184ae05468226938f8262b1cc6745/readthedocs/doc_builder/backends/mkdocs.py#L252
And: https://www.mkdocs.org/about/release-notes/#version-0170-2017-10-19

**Is there anything that requires special attention?**
None.

**Related issues:**
None.
