### PR TITLE
Update Travis to build and push the operator container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 ---
+# yamllint disable rule:line-length
+
 sudo: true
 
 addons:
@@ -13,6 +15,7 @@ env:
   global:
     - GO_METALINTER_VERSION="v2.0.11"
     - OPERATOR_SDK_URL="https://github.com/operator-framework/operator-sdk/releases/download/v0.2.0/operator-sdk-v0.2.0-x86_64-linux-gnu"
+    - CONTAINER_REPO="gluster/anthill"
 
 jobs:
   include:
@@ -30,15 +33,9 @@ jobs:
         - "1.10"
       go_import_path: "github.com/gluster/anthill"
       install:
-        - >
-          curl -L
-          https://raw.githubusercontent.com/golang/dep/master/install.sh
-          | sh
+        - curl -L https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
         # install gometalinter
-        - >
-          curl -L
-          'https://raw.githubusercontent.com/alecthomas/gometalinter/master/scripts/install.sh'
-          | bash -s -- -b ${TRAVIS_HOME}/gopath/bin "${GO_METALINTER_VERSION}"
+        - curl -L 'https://raw.githubusercontent.com/alecthomas/gometalinter/master/scripts/install.sh' | bash -s -- -b ${TRAVIS_HOME}/gopath/bin "${GO_METALINTER_VERSION}"
         # install operator-sdk
         - >
           sudo curl -L -o /usr/local/bin/operator-sdk "${OPERATOR_SDK_URL}"
@@ -52,4 +49,17 @@ jobs:
           --deadline=9m --enable="gofmt" --vendor --debug
           --exclude="zz_generated.deepcopy.go" ./...
           |& stdbuf -oL grep "linter took\\|:warning:\\|:error:"
-        - operator-sdk build docker.io/gluster/anthill
+        - operator-sdk build "${CONTAINER_REPO}"
+      deploy:
+        # Master branch will push the container to :latest
+        - provider: script
+          on:  # yamllint disable-line rule:truthy
+            branch: master
+          script: .travis/push_container.sh ${CONTAINER_REPO} verbatim latest
+        # Tags of the form v + SEMVER (e.g., v1.2.3) will push to the
+        # corresponding container version number (e.g., :1.2.3).
+        - provider: script
+          on:  # yamllint disable-line rule:truthy
+            tags: true
+            condition: $TRAVIS_TAG =~ ^v[0-9]+
+          script: .travis/push_container.sh ${CONTAINER_REPO} version "$TRAVIS_TAG"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,55 @@
 ---
-sudo: false
+sudo: true
 
 addons:
   apt:
     packages:
+      - docker-ce
+      - python
       - realpath
       - ruby
 
+env:
+  global:
+    - GO_METALINTER_VERSION="v2.0.11"
+    - OPERATOR_SDK_URL="https://github.com/operator-framework/operator-sdk/releases/download/v0.2.0/operator-sdk-v0.2.0-x86_64-linux-gnu"
+
 jobs:
   include:
-    - stage: linters
-      name: pre-commit linter
-      language: python
+    - name: Linters
       install:
         - gem install asciidoctor mdl
-        - pip install yamllint
-      script: scripts/pre-commit.sh --require-all
-    - stage: linters
-      name: Documentation linter
-      language: python
+        - pip install --user mkdocs yamllint
+      script:
+        - scripts/pre-commit.sh --require-all
+        - mkdocs build
+    - name: Build
+      language: go
+      go:
+        - stable
+        - "1.10"
+      go_import_path: "github.com/gluster/anthill"
       install:
-        - pip install mkdocs
-      script: mkdocs build
+        - >
+          curl -L
+          https://raw.githubusercontent.com/golang/dep/master/install.sh
+          | sh
+        # install gometalinter
+        - >
+          curl -L
+          'https://raw.githubusercontent.com/alecthomas/gometalinter/master/scripts/install.sh'
+          | bash -s -- -b ${TRAVIS_HOME}/gopath/bin "${GO_METALINTER_VERSION}"
+        # install operator-sdk
+        - >
+          sudo curl -L -o /usr/local/bin/operator-sdk "${OPERATOR_SDK_URL}"
+          && sudo chmod a+x /usr/local/bin/operator-sdk
+      script:
+        - dep ensure -v --vendor-only
+        - >
+          set -o pipefail &&
+          gometalinter -j4
+          --sort path --sort line --sort column
+          --deadline=9m --enable="gofmt" --vendor --debug
+          --exclude="zz_generated.deepcopy.go" ./...
+          |& stdbuf -oL grep "linter took\\|:warning:\\|:error:"
+        - operator-sdk build docker.io/gluster/anthill

--- a/.travis/push_container.sh
+++ b/.travis/push_container.sh
@@ -1,0 +1,27 @@
+#! /bin/bash
+
+# Usage: push_container.sh <repo> <verbatim|version> <tag>
+set -e -o pipefail
+
+image="$1"
+
+if [[ "x$2" == "xversion" ]]; then
+        [[ "$3" =~ ^v([0-9]+.*) ]] || exit 1;
+        tag="${BASH_REMATCH[1]}"
+else
+        tag="$3"
+fi
+
+if [[ "x${QUAY_USERNAME}" != "x" && "x${QUAY_PASSWORD}" != "x" ]]; then
+        echo "$QUAY_PASSWORD" | docker login -u "$QUAY_USERNAME" --password-stdin quay.io
+        finalimage="quay.io/$image:$tag"
+        docker tag "$image" "$finalimage"
+        docker push "$finalimage"
+fi
+
+if [[ "x${DOCKER_USERNAME}" != "x" && "x${DOCKER_PASSWORD}" != "x" ]]; then
+        echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin docker.io
+        finalimage="docker.io/$image:$tag"
+        docker tag "$image" "$finalimage"
+        docker push "$finalimage"
+fi

--- a/pkg/apis/operator/v1alpha1/glustercluster_types.go
+++ b/pkg/apis/operator/v1alpha1/glustercluster_types.go
@@ -2,8 +2,8 @@ package v1alpha1
 
 import (
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // GlusterStorageTarget defines a storage target
@@ -42,11 +42,11 @@ type GlusterNodeStorageDetails struct {
 
 // GlusterNodeTemplate defines a gluster node's template
 type GlusterNodeTemplate struct {
-	Name       string                     `json:"name,omitempty"`
-	Zone       string                     `json:"zone,omitempty"`
-	Threshold *GlusterNodeThreshold       `json:"threshold,omitempty"`
-	Affinity   *corev1.NodeAffinity       `json:"nodeAffinity,omitempty"`
-	Storage    *GlusterNodeStorageDetails `json:"storage,omitempty"`
+	Name      string                     `json:"name,omitempty"`
+	Zone      string                     `json:"zone,omitempty"`
+	Threshold *GlusterNodeThreshold      `json:"threshold,omitempty"`
+	Affinity  *corev1.NodeAffinity       `json:"nodeAffinity,omitempty"`
+	Storage   *GlusterNodeStorageDetails `json:"storage,omitempty"`
 }
 
 // GlusterClusterSpec defines the desired state of GlusterCluster

--- a/pkg/controller/glustercluster/glustercluster_controller.go
+++ b/pkg/controller/glustercluster/glustercluster_controller.go
@@ -58,11 +58,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		IsController: true,
 		OwnerType:    &operatorv1alpha1.GlusterCluster{},
 	})
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 var _ reconcile.Reconciler = &ReconcileGlusterCluster{}
@@ -104,7 +100,7 @@ func (r *ReconcileGlusterCluster) Reconcile(request reconcile.Request) (reconcil
 	pod := newPodForCR(instance)
 
 	// Set GlusterCluster instance as the owner and controller
-	if err := controllerutil.SetControllerReference(instance, pod, r.scheme); err != nil {
+	if err = controllerutil.SetControllerReference(instance, pod, r.scheme); err != nil {
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/controller/glusternode/glusternode_controller.go
+++ b/pkg/controller/glusternode/glusternode_controller.go
@@ -58,11 +58,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		IsController: true,
 		OwnerType:    &operatorv1alpha1.GlusterNode{},
 	})
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 var _ reconcile.Reconciler = &ReconcileGlusterNode{}
@@ -104,7 +100,7 @@ func (r *ReconcileGlusterNode) Reconcile(request reconcile.Request) (reconcile.R
 	pod := newPodForCR(instance)
 
 	// Set GlusterNode instance as the owner and controller
-	if err := controllerutil.SetControllerReference(instance, pod, r.scheme); err != nil {
+	if err = controllerutil.SetControllerReference(instance, pod, r.scheme); err != nil {
 		return reconcile.Result{}, err
 	}
 

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,6 @@
 package version
 
 var (
+	// Version of the Anthill operator
 	Version = "0.0.1"
 )


### PR DESCRIPTION
**Describe what this PR does**
This updates the Travis-CI configuration to build the container image for the operator, and, if successful, it will push the image to quay.io

**Is there anything that requires special attention?**
no

**Related issues:**
- Related to #31
  - Adds automated build and linting of goland files.