### PR TITLE
Container quality

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,37 @@
+#! /bin/bash
+
+set -e -o pipefail
+
+IMAGE=${1-gluster/anthill}
+
+# This sets the version variable to (hopefully) a semver compatible string. We
+# expect released versions to have a tag of vX.Y.Z (with Y & Z optional), so we
+# only look for those tags. For version info on non-release commits, we want to
+# include the git commit info as a "build" suffix ("+stuff" at the end). There
+# is also special casing here for when no tags match.
+VERSION_GLOB="v[:digit:]*"
+# Get the nearest "version" tag if one exists. If not, this returns the full
+# git hash
+NEAREST_TAG="$(git describe --always --tags --match "$VERSION_GLOB" --abbrev=0)"
+# Full output of git describe for us to parse: TAG-<N>-g<hash>-<dirty>
+FULL_DESCRIBE="$(git describe --always --tags --match "$VERSION_GLOB" --dirty)"
+# If full matches against nearest, we found a valid tag earlier
+if [[ $FULL_DESCRIBE =~ ${NEAREST_TAG}-(.*) ]]; then
+        # Build suffix is the last part of describe w/ "-" replaced by "."
+        version="$NEAREST_TAG+${BASH_REMATCH[1]//-/.}"
+else
+        # We didn't find a valid tag, so assume version 0 and everything ends up
+        # in build suffix.
+        version="0.0.0+g${FULL_DESCRIBE//-/.}"
+fi
+builddate="$(date -u '+%Y-%m-%dT%H:%M:%S.%NZ')"
+
+operator-sdk build "$IMAGE"
+docker tag "$IMAGE" "$IMAGE:base-image"
+docker build \
+    --build-arg from="$IMAGE:base-image" \
+    --build-arg version="$version" \
+    --build-arg builddate="$builddate" \
+    -t "$IMAGE" \
+    -f build/Dockerfile.stage2 \
+    .

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,6 @@
 FROM docker.io/centos:7.5.1804
+RUN yum update -y \
+    && yum clean all
 
 USER nobody
 

--- a/build/Dockerfile.stage2
+++ b/build/Dockerfile.stage2
@@ -1,0 +1,14 @@
+ARG from
+FROM ${from}
+
+ARG builddate="(unknown)"
+ARG version="(unknown)"
+
+LABEL build-date="${builddate}"
+LABEL io.k8s.description="Operator to deploy and manage GlusterFS"
+LABEL name="Anthill"
+LABEL Summary="Operator to deploy and manage GlusterFS"
+LABEL vcs-type="git"
+LABEL vcs-url="https://github.com/gluster/anthill"
+LABEL vendor="gluster.org"
+LABEL version="${version}"


### PR DESCRIPTION
**Describe what this PR does**
Since we are now pushing to Quay, I noticed that it performs a security scan on the container. [The results were rather embarrassing](https://quay.io/repository/gluster/anthill/manifest/sha256:2db5477f5b4ea100c0e087c150ae86323556ba1808b48ac8218b76f8c5404282?tab=vulnerabilities). This PR:
- Adds a `yum update` to fix the out of date packages
- Adds a build command that applies "best practices" labels to the container image

**Is there anything that requires special attention?**
The `version` tag code is pretty opaque, but I did my best to comment it. The TL;DR is that the commit ID should be considered "build info" so should be appended after a "+" with components separated by dots.

**Related issues:**
Related to #31