### PR TITLE
Update travis to use the build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ jobs:
           --deadline=9m --enable="gofmt" --vendor --debug
           --exclude="zz_generated.deepcopy.go" ./...
           |& stdbuf -oL grep "linter took\\|:warning:\\|:error:"
-        - operator-sdk build "${CONTAINER_REPO}"
+        - ./build.sh "${CONTAINER_REPO}"
       deploy:
         # Master branch will push the container to :latest
         - provider: script


### PR DESCRIPTION
**Describe what this PR does**
In b22b022 I missed updating Travis to use the build script that applies
the image tags to the built container. This changes Travis to use the
script instead of directly calling `operator-sdk build`.

**Is there anything that requires special attention?**
N/A

**Related issues:**
#46 