### PR TITLE
Increase gometalinter timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ jobs:
           set -o pipefail &&
           gometalinter -j4
           --sort path --sort line --sort column
-          --deadline=9m --enable="gofmt" --vendor --debug
+          --deadline=24h --enable="gofmt" --vendor --debug
           --exclude="zz_generated.deepcopy.go" ./...
           |& stdbuf -oL grep "linter took\\|:warning:\\|:error:"
         - ./build.sh "${CONTAINER_REPO}"


### PR DESCRIPTION
**Describe what this PR does**
We ran into a problem in the csi repo where gml was having timeouts and
failing the build. This change increases the timeout to 24h so we don't
see the same problem in this repo.

**Is there anything that requires special attention?**
N/A

**Related issues:**
gluster/gluster-csi-driver#128