### PR TITLE
Add `dep check` to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ jobs:
           && sudo chmod a+x /usr/local/bin/operator-sdk
       script:
         - travis_retry dep ensure -v --vendor-only
+        - dep check
         - >
           set -o pipefail &&
           gometalinter -j4

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -729,6 +729,7 @@
     "github.com/operator-framework/operator-sdk/version",
     "k8s.io/api/core/v1",
     "k8s.io/apimachinery/pkg/api/errors",
+    "k8s.io/apimachinery/pkg/api/resource",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/runtime",
     "k8s.io/apimachinery/pkg/runtime/schema",


### PR DESCRIPTION
**Describe what this PR does**
Travis should run `dep check` to make sure the Gopkg files are properly
synchronized with each other and the current set of imports in the
source.

**Is there anything that requires special attention?**
N/A

**Related issues:**
N/A